### PR TITLE
Change wording of Android API key generation.

### DIFF
--- a/fmn/web/templates/context.html
+++ b/fmn/web/templates/context.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <div class="page-header">
-  <h1>{{current}} preferences 
+  <h1>{{current}} preferences
     {% if preference.enabled %}
     <small>{{context.description}}</small>
     {% else %}

--- a/fmn/web/templates/profile.html
+++ b/fmn/web/templates/profile.html
@@ -83,8 +83,10 @@
       <a href="https://github.com/fedora-infra/mobile">Fedora Mobile</a>.
     </p>
     <p>
-      This is a temporary key, which should not be relied upon. This
-      functionality will be removed from Fedora Notifications in the future.
+      This is a temporary key, which should not be relied upon for anything
+      except Android notifications. This (API key generation) functionality will
+      be removed from Fedora Notifications in the future, though Fedora Mobile
+      notifications will remain.
     </p>
     <p>
       Your current API key is:


### PR DESCRIPTION
It sounded like we were dropping Android notification support, but we are only
dropping the API key generation support. This will happen after Fedora Mobile
gets native authentication.

Signed-off-by: Ricky Elrod ricky@elrod.me
