### PR TITLE
Remove extra lines from desc on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except:
 
 def get_description():
     with open('README.rst', 'r') as f:
-        return '\n'.join(f.readlines()[2:])
+        return ''.join(f.readlines()[2:])
 
 requires = [
     'SQLAlchemy>=0.8',


### PR DESCRIPTION
This is causing the description to be double-spaced, which is likely also the reason that PyPI is not rendering it as reST.

https://pypi.python.org/pypi/fmn.web