### PR TITLE
Indicate to users that they should check their email.

### DIFF
--- a/fmn/web/templates/context.html
+++ b/fmn/web/templates/context.html
@@ -174,7 +174,7 @@
           {{confirmation.detail_value}}
           {% endif %}
           is {{confirmation.status}}.
-          {% if confirmation.status == "pending" %}
+          {% if confirmation.status in ["pending", "valid"] %}
           You should be contacted soon with confirmation details via {{context.name}}.
           {% endif %}
           </p>

--- a/fmn/web/templates/context.html
+++ b/fmn/web/templates/context.html
@@ -167,13 +167,13 @@
       <div class="panel-body">
         {% if confirmation %}
         <div class="alert alert-{{ {'pending': 'info', 'valid': 'info', 'accepted': 'success', 'rejected': 'danger', 'invalid': 'warning'}[confirmation.status] }}">
-          <p><strong>{{confirmation.status}}</strong> Your confirmation for
+          <p>Your {{ context.detail_name }} for
           {% if context.name == "android" %}
           {{confirmation.detail_value[0:30]}}...
           {% else %}
           {{confirmation.detail_value}}
           {% endif %}
-          is {{confirmation.status}}.
+          is <strong>{{confirmation.status}}</strong>.
           {% if confirmation.status in ["pending", "valid"] %}
           You should be contacted soon with confirmation details via {{context.name}}.
           {% endif %}


### PR DESCRIPTION
@ryanlerch hit this and reported it in IRC.

When people first enter their email address, it is in the 'pending' state.

Then, moments later, a polling producer in a backend fedmsg process notices
that they said they want to use this email address and it tries to email
them with a confirmation link.  When it *sends* that email it moves their
address from the 'pending' state to the 'valid' state (but not yet
'confirmed').

Finally, when they click the link they get, it goes to the 'confirmed'
state.

Ryan hit a race condition where his page reloaded slower than it took that
backend process to email him, so he never got the warning that he should be
going to check his email.

![](http://i.imgur.com/CWazPQL.png)

This change keeps that notice there on the page for both the pending and
valid states.. to make things more clear.