### PR TITLE
Break up searching for examples into 'time windows'.

### DIFF
--- a/fmn/web/static/js/site.js
+++ b/fmn/web/static/js/site.js
@@ -1,11 +1,11 @@
 var examples_loading_message = "Searching for example messages that match this filter <img src='../../../static/img/spinner.gif'/>";
 
-var load_examples = function(page) {
+var load_examples = function(page, endtime) {
     // First, destroy the more button if there is one.
     $('#more-button').remove();
 
     // Then, get the next page of data from the API (relative url)..
-    $.ajax("ex/" + page, {
+    $.ajax("ex/" + page + "/" + endtime, {
         success: examples_success,
         error: examples_error,
     });
@@ -21,7 +21,7 @@ var examples_success = function(data, status, jqXHR) {
         if (title.match('\.\.\.\.\.$') == '.....') {
             $('#examples-container .lead').html(examples_loading_message);
         }
-        load_examples(data.next_page);
+        load_examples(data.next_page, data.endtime);
     } else {
         $('#examples-container .lead').html(
             "The following messages would have matched this filter");
@@ -59,7 +59,7 @@ var examples_success = function(data, status, jqXHR) {
     if (stopping) {
         var button = '<div id="more-button">' +
             '<button class="btn btn-default btn-lg center-block" ' +
-            'onclick="javascript:load_examples(' + data.next_page + ');">' +
+            'onclick="javascript:load_examples(' + data.next_page + ', ' + data.endtime + ');">' +
             '<span class="glyphicon glyphicon-cloud-download"></span>' +
             ' tap for more...' +
             '</button>' +
@@ -80,10 +80,12 @@ var examples_error = function(jqXHR, status, errorThrown) {
 }
 
 $(document).ready(function() {
-    // Kick it off, but only if we're on the right page.
+    // Kick it off, but only if we're on the right page and there are rules.
+    var rules = $("#rules");
     var container = $('#examples-container');
-    if (container.length > 0) {
+    if (container.length > 0 && rules.children().length > 0) {
         $('#examples-container .lead').html(examples_loading_message);
-        load_examples(1);
+        var now = Math.floor(new Date().getTime() / 1000.0);
+        load_examples(1, now);
     }
 });

--- a/fmn/web/templates/filter.html
+++ b/fmn/web/templates/filter.html
@@ -48,7 +48,7 @@
   <div class="col-md-7">
     <p class="lead">Rules defined for this filter:</p>
     <p>(all these rules must be satisfied for the notification to be sent)</p>
-    <div class="list-group">
+    <div id="rules" class="list-group">
     {% for rule in filter.rules %}
       <span class="list-group-item">
         <h4 class="list-group-item-heading">


### PR DESCRIPTION
Limiting the timespan of the query to datagrepper drastically reduces
the time it takes to get results back.

Check out the following script used to produce the following graph:

```python
import requests
import time
import sys

url = 'https://apps.fedoraproject.org/datagrepper/raw/'
attempts = 8

for delta in range(86400, 31104000, 86400):
    results = []
    for attempt in range(attempts):
        start = time.time()
        r = requests.get(url, params=dict(delta=delta))
        assert(r.status_code == 200)
        results.append(time.time() - start)

    # Throw away the max and the min (outliers)
    results.remove(min(results))
    results.remove(min(results))
    results.remove(max(results))
    results.remove(max(results))

    average = sum(results) / len(results)

    print "%i   %f" % (delta / 86400.0, average)
    sys.stdout.flush()
```

![](http://threebean.org/datagrepper-query-times.png)