### PR TITLE
Simplify login.

### DIFF
--- a/fmn/web/templates/master.html
+++ b/fmn/web/templates/master.html
@@ -83,6 +83,12 @@
               </a></li>
               {% else %}
               <li>
+                {% if config['FMN_FEDORA_OPENID'] and config['FMN_ALLOW_FAS_OPENID'] and not config['FMN_ALLOW_GOOGLE_OPENID'] and not config['FMN_ALLOW_YAHOO_OPENID'] and not config['FMN_ALLOW_GENERIC_OPENID'] %}
+                  <a href="{{url_for('fedora_login')}}?next={{url_for('profile_redirect')}}">
+                      <span class="glyphicon glyphicon-log-in"></span>
+                      Login
+                  </a>
+                {% else %}
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                       <span class="glyphicon glyphicon-log-in"></span>
                       Login
@@ -102,6 +108,7 @@
                     <li><a href="{{url_for('login')}}?next={{url_for('profile_redirect')}}">Other OpenID</a></li>
                     {% endif %}
                   </ul>
+                {% endif %}
               </li>
               {% endif %}
             </ul>


### PR DESCRIPTION
If FAS login is allowed, and **all** other login methods are disallowed (this
is what we have running in Fedora production), then make the 'login' button
simply log you in via Fedoauth instead of presenting a dropdown with one
option:  Fedoauth.

Suggested by @puiterwijk.  Fixes fedora-infra/fmn#73.