### PR TITLE
Fix not_reserved negative lookahead regex.

### DIFF
--- a/fmn/web/converters.py
+++ b/fmn/web/converters.py
@@ -2,4 +2,4 @@ from werkzeug.routing import BaseConverter
 
 
 class NotReserved(BaseConverter):
-    regex = "((?!static|api|confirm).)*"
+    regex = "(?!static|api|confirm).*"


### PR DESCRIPTION
Today we hit the embarrassing situation of a user named 'jcapik' being unable
to visit their profile.  I figured out with some curl tests that it was because
'api' was a substring of 'jcapik'.  @pypingou found this werkzeug converter
that we use which seems to be to blame.

In local tests, I was unable to visit a 'jcapik' profile page locally until I
made this change, but I can visit it now after the change.  The api, static,
and confirm endpoints are also still accessible.