### PR TITLE
Make it possible to disable one-shot when disabled

### DIFF
--- a/fmn/web/templates/context.html
+++ b/fmn/web/templates/context.html
@@ -105,17 +105,18 @@
           <input name="context" id="context" value="{{current}}" type="hidden">
           <input name="filter_name" id="filter_name" value="{{fltr.name}}" type="hidden">
           <span class="pull-right">
+            {% if fltr.oneshot %}
+              <button type="submit" name="method" value="disable-oneshot"
+              class="btn btn-primary" data-toggle="tooltip" title="One-shot
+              filters fire only once and then automatically disable
+              themselves.  You can use this feature to watch for a single
+              build, or a single comment somewhere.  This is currently a
+              one-shot filter.">
+                <span class="glyphicon glyphicon-star-empty"></span>
+                Disable one-shot</button>
+            {% endif %}
             {% if fltr.active %}
-              {% if fltr.oneshot %}
-                <button type="submit" name="method" value="disable-oneshot"
-                class="btn btn-primary" data-toggle="tooltip" title="One-shot
-                filters fire only once and then automatically disable
-                themselves.  You can use this feature to watch for a single
-                build, or a single comment somewhere.  This is currently a
-                one-shot filter.">
-                  <span class="glyphicon glyphicon-star-empty"></span>
-                  Disable one-shot</button>
-              {% else %}
+              {% if not fltr.oneshot %}
                 <button type="submit" name="method" value="enable-oneshot"
                 class="btn btn-info" data-toggle="tooltip" title="One-shot
                 filters fire only once and then automatically disable

--- a/fmn/web/templates/filter.html
+++ b/fmn/web/templates/filter.html
@@ -35,15 +35,16 @@
         </span>
 
         <span>
+        {% if filter.oneshot %}
+          <button type="submit" class="btn btn-primary" name="method"
+            value="disable-oneshot" data-toggle="tooltip" title="One-shot
+            filters fire only once and then automatically disable themselves.
+            You can use this feature to watch for a single build, or a single
+            comment somewhere.  This is currently a one-shot filter.">
+            <span class="glyphicon glyphicon-star-empty"></span>Disable one-shot</button>
+        {% endif %}
         {% if filter.active %}
-          {% if filter.oneshot %}
-            <button type="submit" class="btn btn-primary" name="method"
-              value="disable-oneshot" data-toggle="tooltip" title="One-shot
-              filters fire only once and then automatically disable themselves.
-              You can use this feature to watch for a single build, or a single
-              comment somewhere.  This is currently a one-shot filter.">
-              <span class="glyphicon glyphicon-star-empty"></span>Disable one-shot</button>
-          {% else %}
+          {% if not filter.oneshot %}
             <button type="submit" class="btn btn-info" name="method"
               value="enable-oneshot" data-toggle="tooltip" title="One-shot
               filters fire only once and then automatically disable themselves.


### PR DESCRIPTION
Otherwise, it will never be possible to get a filter that includes FMN notifications about yourself off of oneshot:

1. Create a new rule with "A particular user", entering your own username
2. Mark it one-shot
3. The changing to one-shot will trigger it, disabling the rule
4. Re-enabling the rule will trigger one-shot, disabling it again

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>