### PR TITLE
Some more admin view fixes.

### DIFF
--- a/fmn/web/app.py
+++ b/fmn/web/app.py
@@ -224,7 +224,7 @@ def inject_variable():
     openid = None
     contexts = []
     if flask.g.auth.logged_in:
-        openid = flask.g.auth.openid
+        logged_in_user = flask.g.auth.openid
         contexts = fmn.lib.models.Context.all(SESSION)
 
     web_version = get_distribution('fmn.web').version
@@ -456,6 +456,7 @@ def context(openid, context):
     return flask.render_template(
         'context.html',
         current=context.name,
+        openid=openid,
         context=context,
         confirmation=context.get_confirmation(openid),
         preference=pref)
@@ -505,6 +506,7 @@ def filter(openid, context, filter_id):
     return flask.render_template(
         'filter.html',
         current=context,
+        openid=openid,
         filter=filter)
 
 

--- a/fmn/web/templates/master.html
+++ b/fmn/web/templates/master.html
@@ -54,7 +54,7 @@
                 {% else %}
                 <li>
                 {% endif %}
-                <a href="{{url_for('profile', openid=openid)}}">
+                <a href="{{url_for('profile', openid=logged_in_user)}}">
                   <span class="glyphicon glyphicon-user"></span>
                   Profile
                 </a>


### PR DESCRIPTION
The big one was that global ``openid`` var that got injected into the
templates.  It made it so that no matter whose page you were looking at, all
the links and forms would take you back to your own account making it
impossible to actually modify other users accounts.