### PR TITLE
Fix the about page when logged in.

### DIFF
--- a/fmn/web/templates/master.html
+++ b/fmn/web/templates/master.html
@@ -54,7 +54,7 @@
                 {% else %}
                 <li>
                 {% endif %}
-                <a href="{{url_for('profile', openid=logged_in_user)}}">
+                <a href="{{url_for('profile', openid=openid or logged_in_user)}}">
                   <span class="glyphicon glyphicon-user"></span>
                   Profile
                 </a>
@@ -67,7 +67,7 @@
                     {% else %}
                     <li>
                     {% endif %}
-                    <a href="{{url_for('context', openid=openid, context=ctx.name)}}">
+                    <a href="{{url_for('context', openid=openid or logged_in_user, context=ctx.name)}}">
                         <span class="glyphicon glyphicon-{{ctx.icon}}"></span>
                         {{ctx.name}}
                     </a>


### PR DESCRIPTION
This is a weird little regression that comes from trying to make the interface
more flexible for admins.  To explain:

The ``openid`` value here is the openid of the person on the page you're
looking at (for all pages.. this is the master.html template from which all
other templates inherit).  The ``logged_in_user`` here is the openid of, you
guessed it, the logged in user.

So, when you're the admin ralph.id.fedoraproject.org and you're looking at the
profile of kevin.id.fedoraproject.org.  Those links for the context are
supposed to make it easy to just click the 'irc' link in the top nav menu to
take you to kevin's irc preferences.. even though you're logged in as the admin
ralph.

That worked fine on most pages (profiles, contexts, filters, etc...) because
most pages *have* a user object that they are **about**.  The one exception is
the ``/about`` which is **not** about a user.. but is just a raw document.

The code in this change makes it such that when you are logged in and you are
looking at the ``/about`` page, those 'irc' and 'email' links in the navbar
take you to **your** preferences (since the ``openid`` variable is
undefined/``None``).

Fixes fedora-infra/fmn#82.