### PR TITLE
Specify a rule_id when executing an action on a rule

### DIFF
--- a/fmn/web/app.py
+++ b/fmn/web/app.py
@@ -939,6 +939,7 @@ def handle_rule():
     context = form.context.data
     filter_id = form.filter_id.data
     code_path = form.rule_name.data
+    rule_id = form.rule_id.data
     method = (form.method.data or flask.request.method).upper()
     # Extract arguments to rules using the extra information provided
     known_args = ['openid', 'filter_id', 'context', 'rule_name']
@@ -976,9 +977,9 @@ def handle_rule():
         if method == 'POST':
             filter.add_rule(SESSION, valid_paths, code_path, **arguments)
         elif method == 'NEGATE':
-            filter.negate_rule(SESSION, code_path)
+            filter.negate_rule(SESSION, code_path, rule_id)
         elif method == 'DELETE':
-            filter.remove_rule(SESSION, code_path)  # , **arguments)
+            filter.remove_rule(SESSION, code_path, rule_id)  # , **arguments)
         else:
             raise NotImplementedError("This is impossible.")
     except (ValueError, KeyError) as e:

--- a/fmn/web/forms.py
+++ b/fmn/web/forms.py
@@ -37,6 +37,7 @@ class RuleForm(Form):
     context = TextField('context', [validators.Required()])
     filter_id = IntegerField('filter_id', [validators.Required()])
     rule_name = TextField('rule_name', [validators.Required()])
+    rule_id = IntegerField('rule_id', [validators.Required()])
     method = TextField('method')
 
 

--- a/fmn/web/templates/filter.html
+++ b/fmn/web/templates/filter.html
@@ -117,6 +117,7 @@
               <input name="openid" id="openid" value="{{openid}}" type="hidden">
               <input name="context" id="context" value="{{current}}" type="hidden">
               <input name="filter_id" id="filter_id" value="{{filter.id}}" type="hidden">
+              <input name="rule_id" id="rule_id" value="{{rule.id}}" type="hidden">
               {% for key, value in rule.arguments.iteritems() %}
               <dt>{{key}}</dt><dd id="{{key}}{{rule.id}}">
                 <span class="read">{{value}}
@@ -142,6 +143,7 @@
                 <input name="openid" id="openid" value="{{openid}}" type="hidden">
                 <input name="context" id="context" value="{{current}}" type="hidden">
                 <input name="filter_id" id="filter_id" value="{{filter.id}}" type="hidden">
+                <input name="rule_id" id="rule_id" value="{{rule.id}}" type="hidden">
                 {% if rule.negated %}
                 <button type="submit" class="btn btn-success btn-xs"
                   name="method" value="negate" data-toggle="tooltip"


### PR DESCRIPTION
Multiple rules can have the same context, behavior was unstable.

Please see https://github.com/fedora-infra/fmn.lib/pull/54

The test case is the following one:

Create a rule for an email address, add 3 conditions: the username is "foo", "bar" and "baz". Try to negate "bar" and "baz". You can't...

This fixes the bug.