### PR TITLE
Add a runserver.py script to the repository root

### DIFF
--- a/fmn/web/main.py
+++ b/fmn/web/main.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 """ The flask application """
 
-## These two lines are needed to run on EL6
-__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
-import pkg_resources
+# These two lines are needed to run on EL6
+__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']  # NOQA
+import pkg_resources  # NOQA
 
 from fmn.web.app import app
 
+
 if __name__ == '__main__':
     app.debug = True
+    print('Running the FMN web application from fmn/web/main.py is deprecated,'
+          ' please use runserver.py in the root of the repository.')
     app.run()

--- a/runserver.py
+++ b/runserver.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Run the flask application in a development server"""
+
+# These two lines are needed to run on EL6
+__requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']  # NOQA
+import pkg_resources  # NOQA
+
+import argparse
+import os
+
+from fmn.web.app import app
+
+
+parser = argparse.ArgumentParser(
+    description='Run the anitya app')
+parser.add_argument(
+    '--config', '-c', dest='config',
+    help='Configuration file to use for fmn.web')
+parser.add_argument(
+    '--debug', dest='debug', action='store_true',
+    default=False,
+    help='Expand the level of data returned.')
+parser.add_argument(
+    '--profile', dest='profile', action='store_true',
+    default=False,
+    help='Profile the anitya application.')
+parser.add_argument(
+    '--port', '-p', default=5000,
+    help='Port for the flask application.')
+parser.add_argument(
+    '--host', default='127.0.0.1',
+    help='IP address for the flask application to bind to.'
+)
+
+args = parser.parse_args()
+
+
+if args.profile:
+    from werkzeug.contrib.profiler import ProfilerMiddleware
+    app.config['PROFILE'] = True
+    app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
+
+
+if args.config:
+    config = args.config
+    if not config.startswith('/'):
+        here = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+        config = os.path.join(here, config)
+    os.environ['FMN_WEB_CONFIG'] = config
+
+
+app.debug = True
+app.run(port=int(args.port), host=args.host)


### PR DESCRIPTION
There is a fmn/web/main.py module to start the web application in a
development server. However, it's not configurable without editing the
file and it also is not particularly useful to anyone except for
developers. It now prints a deprecation notice and a new
``runserver.py`` script has been added to the repository root for
developer use.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>